### PR TITLE
Totcalib pixel resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ TOTCalib/TOTCalibDict*
 *.creator
 *.config
 *.files
+*creator.user
+
+// MacOs
+*.DS_Store

--- a/TOTCalib/README.md
+++ b/TOTCalib/README.md
@@ -11,6 +11,7 @@ Run it with ROOT6 as: root -l runSavePixelResolution.C
 Source file must be a MAFOutput root file from TOTCalibrationPreparation algo (in mafalda_framework).
 It generates a root file (output_pixelResolution.root) that contains histos, kernel and fit functions.
 This root file is intended to be used with runExplorePixelResolution.C
+If calibration files are given in argument when calling the function, it records calibrated histograms and fits as well (compatible with runExplorePixelResolution.C). The 4 text files (e.g. obtained by running runTOTCalib.C) must be given in the order a,b,c,t. 
 
 ------------- runExplorePixelResolution.C --------------
 Macro to display maps of values recorded by runSavePixelResolution.C.
@@ -22,3 +23,4 @@ root [3] c1->AddExec("",".x runExplorePixelTOTResolution.C");
 root [4] c1->ToggleEventStatus(); // to display pixel coordinate in the status bar (bottom line of canvas)
 root [5] gStyle->SetPalette(52); // Better vizualisation with black & white.
 When pointing a specific pixel with the mouse it opens a canvas with its histogram, kernel and fit function.
+If calib files were used in runSavePixelResolution.C, a second canvas is opened which displays the calibrated spectrum with a gaussian fit.

--- a/TOTCalib/README.md
+++ b/TOTCalib/README.md
@@ -1,0 +1,24 @@
+How to use macros:
+
+-------------------- runTOTCalib.C --------------------
+Macro to run the TOT calibration.
+Run it with ROOT6 as: root -l runTOTCalib.C
+Input sources file must be MAFOutput root files from TOTCalibrationPreparation algo (in mafalda_framework).
+
+-------------- runSavePixelResolution.C ---------------
+Macro to record spectra and fits for each pixel from one source file only.
+Run it with ROOT6 as: root -l runSavePixelResolution.C
+Source file must be a MAFOutput root file from TOTCalibrationPreparation algo (in mafalda_framework).
+It generates a root file (output_pixelResolution.root) that contains histos, kernel and fit functions.
+This root file is intended to be used with runExplorePixelResolution.C
+
+------------- runExplorePixelResolution.C --------------
+Macro to display maps of values recorded by runSavePixelResolution.C.
+Run it with ROOT6/CLING as:
+root [0] TFile f("output_pixelResolution.root");
+root [1] SingleHitFitMeans->Draw("colz"); // other histograms available
+root [2] gStyle->SetOptStat(0); // remove stat box
+root [3] c1->AddExec("",".x runExplorePixelTOTResolution.C");  
+root [4] c1->ToggleEventStatus(); // to display pixel coordinate in the status bar (bottom line of canvas)
+root [5] gStyle->SetPalette(52); // Better vizualisation with black & white.
+When pointing a specific pixel with the mouse it opens a canvas with its histogram, kernel and fit function.

--- a/TOTCalib/TOTCalib.cpp
+++ b/TOTCalib/TOTCalib.cpp
@@ -1439,8 +1439,8 @@ void TOTCalib::SavePixelResolution(TString file_a, TString file_b, TString file_
             map<int, double>::iterator EpointItr = Epoint.begin();
         
             // The selected fitting function.  Do not delete in this scope !
-            TF1 * gf;
-            TF1 * gf_calibrated;
+            TF1 * gf = nullptr;
+            TF1 * gf_calibrated = nullptr;
         
             // Obtain the histogram for this pixel
             int totval = 0;
@@ -1453,8 +1453,8 @@ void TOTCalib::SavePixelResolution(TString file_a, TString file_b, TString file_
 //            cout<<"t: "<<m_t[pix]<<endl;
 //            cout<<"--------"<<endl;
             
-            TH1I * hf;
-            TH1I * hf_calibrated;            
+            TH1I * hf = nullptr;
+            TH1I * hf_calibrated = nullptr;            
             
             // The data histogram
             hf = s->GetHisto(pix, "SavePixelResolution");
@@ -1565,7 +1565,7 @@ void TOTCalib::SavePixelResolution(TString file_a, TString file_b, TString file_
        int nCalibPoints = (int)calibPoints.size();
        
        // Get kernel function for this pixel
-       TF1 * kf;
+       TF1 * kf = nullptr;
        kf = m_allSources[sour_num]->GetKernelDensityFunction(pix);
        
        // Get fit results for this pixel
@@ -1705,7 +1705,7 @@ TH1I * TOTCalib::GetHistoCalibrated(int pix, TString extraName, double energymax
 	name += pix;
     
     double rangemax = energymax*1.8;
-    double binsize = 0.1; // keV
+    double binsize = .2; // keV
     int nbins = rangemax/binsize;
 	TH1I * h = new TH1I(name, name, nbins, 0, rangemax);
 	vector<double> hist = m_calibhistos[pix];

--- a/TOTCalib/TOTCalib.h
+++ b/TOTCalib/TOTCalib.h
@@ -187,7 +187,11 @@ public :
 	void Blender(TOTCalib * s2, TString outputName, int = 0);
 	void Blender(TString, int = 0);
 
-    void SavePixelResolution();
+    void SavePixelResolution(TString = "", TString = "", TString = "", TString = "");
+    void GetCoeffFromFiles(double *, double *, double *, double *, const char *, const char *, const char *, const char *, int, int);
+    void GetCuadraticSolutions(pair<int,int>, int, double &, double &, double &, double *, double *, double *, double *);
+    double GetE(pair<int,int>, int tot, double *, double *, double *, double *);
+    TH1I *GetHistoCalibrated(int, TString, double, double *, double *, double *, double *);
     
 	void ProcessOneSource(TOTCalib * s, store * sto, TGraphErrors * g, int pix, int & cntr);
 	void ReorderSources();

--- a/TOTCalib/TOTCalib.h
+++ b/TOTCalib/TOTCalib.h
@@ -187,6 +187,8 @@ public :
 	void Blender(TOTCalib * s2, TString outputName, int = 0);
 	void Blender(TString, int = 0);
 
+    void SavePixelResolution();
+    
 	void ProcessOneSource(TOTCalib * s, store * sto, TGraphErrors * g, int pix, int & cntr);
 	void ReorderSources();
 

--- a/TOTCalib/runExplorePixelTOTResolution.C
+++ b/TOTCalib/runExplorePixelTOTResolution.C
@@ -58,6 +58,8 @@ double fit_func_lowen(double * x, double * par) {
 void runExplorePixelTOTResolution()
 {
 
+    //----------------------- Look for trees and branches in root file --------------------------------    
+    
     TTree *T = (TTree*)f.Get("SavePixelResolution");
     Int_t pixelID;
     TH1I *hpx = 0;
@@ -82,29 +84,27 @@ void runExplorePixelTOTResolution()
     T->SetBranchAddress("Fitb",&br_double_bfit);
     T->SetBranchAddress("Fitc",&br_double_cfit);
     T->SetBranchAddress("Fitt",&br_double_tfit);
-    
-    
-    // ***************** NEW ******************************
-    
+        
     // In case calibrated data is present    
     vector<double> *br_double_sigmafit_calibrated=0; 
     vector<double> *br_double_totmeanfit_calibrated=0;
     vector<double> *br_double_constantfit_calibrated=0;
-    TH1I *hpx_calibrated = 0;
-    
-    static TString invalidBranch("FitConstant_calibrated");
-    TObject* calib_branch = T->GetListOfBranches()->FindObject(invalidBranch);
+    TH1I *hpx_calibrated = 0;    
+    static TString calibBranch("FitConstant_calibrated");
+    TObject* calib_branch = T->GetListOfBranches()->FindObject(calibBranch);
     bool calib_present = false;
     if (calib_branch!=nullptr){ calib_present = true;}
-    //if (calib_present){
+    if (calib_present){
         T->SetBranchAddress("Histo_Spectrum_calibrated",&hpx_calibrated);        
         T->SetBranchAddress("FitConstant_calibrated",&br_double_constantfit_calibrated);
         T->SetBranchAddress("FitMean_calibrated",&br_double_totmeanfit_calibrated);
         T->SetBranchAddress("FitSigma_calibrated",&br_double_sigmafit_calibrated);         
-    //}
-    // ***************** NEW ******************************
+    }  
     
 
+    //------------------------------ Plot interactive histograms ----------------------------------------
+    
+    
     T->GetEntry(0);
     Int_t FirstPixelInTree = pixelID;
 
@@ -132,8 +132,7 @@ void runExplorePixelTOTResolution()
     //create or set the new canvas c2
     TVirtualPad *padsav = gPad;
     TCanvas *c2 = (TCanvas*)gROOT->GetListOfCanvases()->FindObject("c2");
-    if(c2) delete c2->GetPrimitive("Projection");
-    else   c2 = new TCanvas("c2");
+    if(c2) {delete c2->GetPrimitive("Projection");} else {c2 = new TCanvas("c2");}
     c2->cd();
 
     //draw slice corresponding to mouse position
@@ -149,6 +148,8 @@ void runExplorePixelTOTResolution()
     T->GetEntry(PixelToPlot-FirstPixelInTree); // I soustract firstPixelInTree for cases where root file starts with a pixelID different than 0.
 
     // First, draw histogram and kernel function  (stored in root file)
+    hpx->GetXaxis()->SetTitle("TOT");
+    hpx->GetXaxis()->SetTitle("Counts");    
     hpx->Draw("HIST");
     kernel_func->Draw("same");
     kernel_func->SetLineColor(kBlack);
@@ -192,7 +193,8 @@ void runExplorePixelTOTResolution()
     c2->Update();
     padsav->cd();
     
-    //-------------------------------------------------------------------------------
+    
+    //------------------- Add another canvas if calibrated data is present in root file ---------------------------------
     
     if (calib_present){
         
@@ -204,6 +206,8 @@ void runExplorePixelTOTResolution()
         c3->cd();
     
         // First, draw histogram and kernel function  (stored in root file)
+        hpx_calibrated->GetXaxis()->SetTitle("Energy (keV)");
+        hpx_calibrated->GetXaxis()->SetTitle("Counts"); 
         hpx_calibrated->Draw("HIST");
         
         // Secondly, draw fit functions (from parameters stored in root file)

--- a/TOTCalib/runExplorePixelTOTResolution.C
+++ b/TOTCalib/runExplorePixelTOTResolution.C
@@ -1,0 +1,174 @@
+/*
+ * Author: Thomas Billoud <billoud@lps.umontreal.ca>
+ * 
+ * File to display pixel spectra when mouse is pointing at a particuler in
+ * a map from output_pixelResolution root file (e.g. "SingleHitFitMeans").
+ *
+ * Use it in CINT as (you need to be in TOTCalib folder):
+ * root [] TFile f("output_pixelResolution.root");
+ * root [] SingleHitFitMeans->Draw("colz");
+ * root [] gStyle->SetOptStat(0);
+ * root [] c1->AddExec("",".x runExplorePixelTOTResolution.C");
+ * root [] c1->ToggleEventStatus(); // to display pixel coordinate in the status bar (bottom line of canvas)
+ * root [] gStyle->SetPalette(52); // Easier to distinguish abnormal fits by eye with black & white picture.
+ *
+ * Inspired from exec2.C in root examples
+*/
+
+int XYtoX(int pixX, int pixY, int dimX){
+    return pixY * dimX + pixX;
+}
+
+double fit_func_lowen(double * x, double * par) {
+
+    // Function proposed in J. Jakubek / Nuclear Instruments and Methods in Physics Research A 633 (2011) S262–S266
+
+    // independent var
+    Double_t xx = x[0]; // TOT
+
+    // parameters for gaussian
+    Double_t gconst = par[0];
+    Double_t mean = par[1];
+    Double_t sigma = par[2];
+
+    // surrogate ^ -1
+    Double_t a = par[3];
+    Double_t b = par[4];
+    Double_t c = par[5];
+    Double_t t = par[6];
+
+    // Inverse of the surrogate ( = energy in keV)
+    Double_t surrogate_inverse, delta, num1, num2, denum;
+    delta = TMath::Power((b-a*t-xx),2) - 4 * a * (xx*t-c-b*t);
+    num1 = a*t + xx - b;
+    num2 = TMath::Sqrt(delta) ;
+    denum = 2 * a;
+    surrogate_inverse = (num1 +  num2) / denum;
+
+    // Gaussian of the inversed surrogate
+    Double_t arg = (surrogate_inverse - mean)/sigma;
+    Double_t func = gconst * TMath::Exp(-0.5*arg*arg);
+
+    return func;
+}
+
+
+
+void runExplorePixelTOTResolution()
+{
+
+    TTree *T = (TTree*)f.Get("SavePixelResolution");
+    Int_t pixelID;
+    TH1I *hpx = 0;
+    TF1 *kernel_func = 0;
+    vector<double> *br_double_sigmafit=0;
+    vector<double> *br_double_totmeanfit=0;
+    vector<double> *br_double_constantfit=0;
+    vector<double> *br_double_afit=0;
+    vector<double> *br_double_bfit=0;
+    vector<double> *br_double_cfit=0;
+    vector<double> *br_double_tfit=0;
+    
+    Int_t selectedPeakID;
+    T->SetBranchAddress("pixelID",&pixelID);
+    T->SetBranchAddress("selectedPeakID",&selectedPeakID);
+    T->SetBranchAddress("Histo_Spectrum",&hpx);
+    T->SetBranchAddress("Kernel_Function",&kernel_func);
+    T->SetBranchAddress("FitSigma",&br_double_sigmafit);
+    T->SetBranchAddress("FitMean",&br_double_totmeanfit);
+    T->SetBranchAddress("FitConstant",&br_double_constantfit);
+    T->SetBranchAddress("Fita",&br_double_afit);
+    T->SetBranchAddress("Fitb",&br_double_bfit);
+    T->SetBranchAddress("Fitc",&br_double_cfit);
+    T->SetBranchAddress("Fitt",&br_double_tfit);
+
+    T->GetEntry(0);
+    Int_t FirstPixelInTree = pixelID;
+
+    TObject *select = gPad->GetSelected();
+    if(!select) return;
+    if (!select->InheritsFrom(TH2::Class())) {gPad->SetUniqueID(0); return;}
+    gPad->GetCanvas()->FeedbackMode(kTRUE);
+
+    //erase old position and draw a line at current position
+    int pyold = gPad->GetUniqueID();
+    int px = gPad->GetEventX();
+    int py = gPad->GetEventY();
+    float uxmin = gPad->GetUxmin();
+    float uxmax = gPad->GetUxmax();
+    int pxmin = gPad->XtoAbsPixel(uxmin);
+    int pxmax = gPad->XtoAbsPixel(uxmax);
+    if(pyold) gVirtualX->DrawLine(pxmin,pyold,pxmax,pyold);
+    gVirtualX->DrawLine(pxmin,py,pxmax,py);
+    gPad->SetUniqueID(py);
+    Float_t upx = gPad->AbsPixeltoX(px);
+    Float_t x = gPad->PadtoX(upx);
+    Float_t upy = gPad->AbsPixeltoY(py);
+    Float_t y = gPad->PadtoY(upy);
+
+    //create or set the new canvas c2
+    TVirtualPad *padsav = gPad;
+    TCanvas *c2 = (TCanvas*)gROOT->GetListOfCanvases()->FindObject("c2");
+    if(c2) delete c2->GetPrimitive("Projection");
+    else   c2 = new TCanvas("c2");
+    c2->cd();
+
+    //draw slice corresponding to mouse position
+    TH2 *h = (TH2*)select;
+    Int_t binx = h->GetXaxis()->FindBin(x);
+    Int_t biny = h->GetYaxis()->FindBin(y);
+    Int_t PixCoorX = binx -1 ;
+    Int_t PixCoorY = biny -1 ;
+
+    // Load root file entry of pointed pixel
+    int PixelToPlot = XYtoX(PixCoorX,PixCoorY,256);
+    Int_t nevent = T->GetEntries();
+    T->GetEntry(PixelToPlot-FirstPixelInTree); // I soustract firstPixelInTree for cases where root file starts with a pixelID different than 0.
+
+    // Firstly, draw histogram and kernel function  (stored in root file)
+    hpx->Draw("HIST");
+    kernel_func->Draw("same");
+    kernel_func->SetLineColor(kBlack);
+    kernel_func->SetLineStyle(2);
+    kernel_func->SetLineWidth(1);
+
+    // Secondly, draw fit functions (from parameters stored in root file)
+    TF1 *fit_func = new TF1("gf_linear", "gaus(0)", 0.,hpx->GetNbinsX());
+    TF1 *fit_func_lowenergy = new TF1("gf_lowen",fit_func_lowen, 0.,hpx->GetNbinsX(),7);    
+    Int_t number_of_fitted_peaks = br_double_constantfit->size();
+    for(Int_t i=0 ; i<number_of_fitted_peaks ; i++ ) {
+
+       if (br_double_afit->at(i) == 0.0){
+           fit_func->SetParameter( 0, br_double_constantfit->at(i) ); // I don't get the use of orderCntr in DrawFullPixelCalib
+           fit_func->SetParameter( 1, br_double_totmeanfit->at(i) );
+           fit_func->SetParameter( 2, br_double_sigmafit->at(i));
+           if (i==selectedPeakID) {
+               fit_func->SetLineColor(kGreen);
+           }else{
+               fit_func->SetLineColor(kRed);
+           }
+           fit_func->DrawCopy("same");  
+       }else{
+           fit_func_lowenergy->SetParameter( 0, br_double_constantfit->at(i) ); // I don't get the use of orderCntr in DrawFullPixelCalib
+           fit_func_lowenergy->SetParameter( 1, br_double_totmeanfit->at(i) );
+           fit_func_lowenergy->SetParameter( 2, br_double_sigmafit->at(i));
+           fit_func_lowenergy->SetParameter( 3, br_double_afit->at(i));
+           fit_func_lowenergy->SetParameter( 4, br_double_bfit->at(i));
+           fit_func_lowenergy->SetParameter( 5, br_double_cfit->at(i));
+           fit_func_lowenergy->SetParameter( 6, br_double_tfit->at(i));
+                      
+           if (i==selectedPeakID) {
+               fit_func_lowenergy->SetLineColor(kGreen);
+           }else{
+               fit_func_lowenergy->SetLineColor(kRed);
+           }
+           fit_func_lowenergy->DrawCopy("same");
+       }
+
+    }
+
+    c2->Update();
+    padsav->cd();
+
+}
+

--- a/TOTCalib/runSavePixelResolution.C
+++ b/TOTCalib/runSavePixelResolution.C
@@ -37,13 +37,16 @@ void runSavePixelResolution() {
     pCu->SetKernelBandWidth(20.); // Kernel Bandwidth
     pCu->Loop(); // Run this source
     
-    TString calib_folder = "/Users/thomasbilloud/workspace/DETECTEURS/2017_02_GaAs500_E06W0203/calib/2017_04_27_AmCdCu/";
-    TString a = calib_folder+"TestGaAs500_a.txt";
-    TString b = calib_folder+"TestGaAs500_b.txt";
-    TString c = calib_folder+"TestGaAs500_c.txt";
-    TString t = calib_folder+"TestGaAs500_t.txt";
+    // Without calibration
+     pCu->SavePixelResolution();  
     
-    pCu->SavePixelResolution(a,b,c,t);    
+    // With calibration
+//    TString calib_folder = "/Users/thomasbilloud/workspace/DETECTEURS/2017_02_GaAs500_E06W0203/calib/2017_04_27_AmCdCu/";
+//    TString a = calib_folder+"TestGaAs500_a.txt";
+//    TString b = calib_folder+"TestGaAs500_b.txt";
+//    TString c = calib_folder+"TestGaAs500_c.txt";
+//    TString t = calib_folder+"TestGaAs500_t.txt";
+//    pCu->SavePixelResolution(a,b,c,t);    
 
 
 }

--- a/TOTCalib/runSavePixelResolution.C
+++ b/TOTCalib/runSavePixelResolution.C
@@ -1,0 +1,42 @@
+/*
+ *  Author: Thomas Billoud <billoud@lps.umontreal.ca>
+ *  Macro to save spectra maps for one source (output root file intended to be used with runExplorePixelResolution.C)
+ */
+
+#include <TH2I.h>
+#include <TString.h>
+#include <TROOT.h>
+#include <TSystem.h>
+
+#include <vector>
+
+using namespace std;
+
+class TOTCalib;
+
+// Prototypes and a few harmless globals
+int nTotalFrames;
+int minpix; int maxpix;
+
+R__LOAD_LIBRARY(libTOTCalib) // ROOT6 (cling)
+
+void runSavePixelResolution() {
+
+    nTotalFrames = -1;            	 // -1: run all frames in input dataset
+    //minpix = 0; maxpix = 256*256-1;  // Work on this set of pixels
+    minpix = 32741; maxpix = 32842;  // Work on this set of pixels
+
+    // Load calibration library
+    gSystem->Load("libTOTCalib.so");
+
+    TString folder_local = "/Users/thomasbilloud/workspace/DATA/MAFOutput/2017-02-GaAs500-E06W0203/";
+    
+    // Process one source ///////////////////////////////////////////////////////////////////////////////////////////
+    TOTCalib * pCu = new TOTCalib(folder_local+"MAFOutput_MPXNtuple_Cu_-50V.root","Cu-fluo", minpix, maxpix, 200, nTotalFrames);
+    pCu->SetVerboseLevel(TOTCalib::__VER_INFO);
+    pCu->SetKernelBandWidth(20.); // Kernel Bandwidth
+    pCu->Loop(); // Run this source
+    pCu->SavePixelResolution();    
+
+
+}

--- a/TOTCalib/runSavePixelResolution.C
+++ b/TOTCalib/runSavePixelResolution.C
@@ -24,7 +24,7 @@ void runSavePixelResolution() {
 
     nTotalFrames = -1;            	 // -1: run all frames in input dataset
     //minpix = 0; maxpix = 256*256-1;  // Work on this set of pixels
-    minpix = 32741; maxpix = 32842;  // Work on this set of pixels
+    minpix = 32741; maxpix = 32841;  // Work on this set of pixels
 
     // Load calibration library
     gSystem->Load("libTOTCalib.so");
@@ -33,10 +33,17 @@ void runSavePixelResolution() {
     
     // Process one source ///////////////////////////////////////////////////////////////////////////////////////////
     TOTCalib * pCu = new TOTCalib(folder_local+"MAFOutput_MPXNtuple_Cu_-50V.root","Cu-fluo", minpix, maxpix, 200, nTotalFrames);
-    pCu->SetVerboseLevel(TOTCalib::__VER_INFO);
+    pCu->SetVerboseLevel(TOTCalib::__VER_QUIET);
     pCu->SetKernelBandWidth(20.); // Kernel Bandwidth
     pCu->Loop(); // Run this source
-    pCu->SavePixelResolution();    
+    
+    TString calib_folder = "/Users/thomasbilloud/workspace/DETECTEURS/2017_02_GaAs500_E06W0203/calib/2017_04_27_AmCdCu/";
+    TString a = calib_folder+"TestGaAs500_a.txt";
+    TString b = calib_folder+"TestGaAs500_b.txt";
+    TString c = calib_folder+"TestGaAs500_c.txt";
+    TString t = calib_folder+"TestGaAs500_t.txt";
+    
+    pCu->SavePixelResolution(a,b,c,t);    
 
 
 }


### PR DESCRIPTION
New feature to save and analyse interactively per-pixel x-ray spectra and fits from a single source. This can be used as a first step before calibration or to analyse the homogeneity of a detector. One macro is used to save data from a source to a root file (runSavePixelResolution.C). Another one is used to plot histograms and fits by pointing pixels from a map of the detector with the mouse (runExplorePixelResolution.C). See README.md for more details.