### PR TITLE
Bug fix - ./MAFTools/MAFTools.h:177:31: error: too many arguments pro…

### DIFF
--- a/mafalda_framework/MAFTools/MAFTools.h
+++ b/mafalda_framework/MAFTools/MAFTools.h
@@ -174,7 +174,7 @@ bool ClusterTouchesBorder(cluster, int, int, int);
 double GetTOTOfHotestsPixel(cluster cl);
 
 bool GoodCandidateGraph2D(blob);
-void PrintMatrix(int **, int, int);
+void PrintMatrix(int **, int);
 int ** RefineGridOnce(int ** c, int * , int *);
 
 list< pair < pair<int, int>, int > >::iterator FindHotestPixel(list< pair < pair<int, int>, int > > *);


### PR DESCRIPTION
…vided to function-like macro invocation

void PrintMatrix(int **, int, int);


This mismatch blocks compilation of runExample.C